### PR TITLE
Use Bash best practices and fix printf syntax errors

### DIFF
--- a/i3stsh
+++ b/i3stsh
@@ -53,7 +53,7 @@ do
 
     # BATTERY
     printf '{"name":"bat","color":"#FFFFFF","full_text":"%s% "}' "$bat"
-    
+
 
     printf "],\n"
     # This whole counter thing is we don't run some commands to often

--- a/i3stsh
+++ b/i3stsh
@@ -10,7 +10,7 @@ do
     printf '['
 
     # counter commands first
-    if [ "$counter" == "0" ]
+    if (( counter == 0 ))
     then
         essid=$(iwconfig wlp3s0 | awk -F '"' '/ESSID/ {print $2}')
         strength=$(nmcli -t -f active,ssid,signal dev wifi|grep yes|cut -d':' -f3)
@@ -58,11 +58,11 @@ do
     printf "],\n"
     # This whole counter thing is we don't run some commands to often
     # (~30secs), but let the time and other things counter every seccond.
-    if [ "$counter" -lt "6" ]
+    if (( counter < 6 ))
     then
-        let counter=$counter+1
+      (( counter++ ))
     else
-        counter=0
+      counter=0
     fi
     sleep 5
 done

--- a/i3stsh
+++ b/i3stsh
@@ -24,7 +24,7 @@ do
     bat=$(upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | cut -d':' -f2 | sed 's/ //g')
 
     # WIFI:
-    printf '{"name":"wifi","color":"#FFFFFF","full_text":"'"$essid"' '"$strength"'%%"},'
+    printf '{"name":"wifi","color":"#FFFFFF","full_text":"%s %s%%"},' "$essid" "$strength"
 
     # VPN:
     if [ "$vpn_state" == "tun0: connected to tun0" ]
@@ -37,22 +37,22 @@ do
     # VOLUME:
     if [ "$mute" != "off" ]
     then
-        printf '{"name":"vol","color":"#FFFFFF","full_text":"VOL: '"$vol"'%%"},'
+        printf '{"name":"vol","color":"#FFFFFF","full_text":"VOL: %s%"},' "$vol"
     else
-        printf '{"name":"vol","color":"#FFFF00","full_text":"MUTED ('"$vol"'%%)"},'
+        printf '{"name":"vol","color":"#FFFF00","full_text":"MUTED (%s%)"},' "$vol"
     fi
 
     # DOY:
-    printf '{"name":"doy","color":"#FF00FF","full_text":"DOY: '"$doy"'"},'
+    printf '{"name":"doy","color":"#FF00FF","full_text":"DOY: %s"},' "$doy"
 
     # DATE:
-    printf '{"name":"date","color":"#FFFFFF","full_text":"'"$date"'"},'
+    printf '{"name":"date","color":"#FFFFFF","full_text":"%s"},' "$date"
 
     # TIME:
-    printf '{"name":"time","color":"#00AAFF","full_text":"'"$ti"'"},'
+    printf '{"name":"time","color":"#00AAFF","full_text":"%s"},' "$ti"
 
     # BATTERY
-    printf '{"name":"bat","color":"#FFFFFF","full_text":"'"$bat"'%% "}'
+    printf '{"name":"bat","color":"#FFFFFF","full_text":"%s% "}' "$bat"
     
 
     printf "],\n"

--- a/i3stsh
+++ b/i3stsh
@@ -12,16 +12,16 @@ do
     # counter commands first
     if [ "$counter" == "0" ]
     then
-        essid="`iwconfig wlp3s0 | awk -F '"' '/ESSID/ {print $2}'`"
-        strength="`nmcli -t -f active,ssid,signal dev wifi|grep yes|cut -d':' -f3`"
-        vpn_state="`nmcli | grep "tun0: connected to tun0"`"
-        doy="`date "+%j"`"
-        date="`date "+%F"`"
+        essid=$(iwconfig wlp3s0 | awk -F '"' '/ESSID/ {print $2}')
+        strength=$(nmcli -t -f active,ssid,signal dev wifi|grep yes|cut -d':' -f3)
+        vpn_state=$(nmcli | grep "tun0: connected to tun0")
+        doy=$(date "+%j")
+        date=$(date "+%F")
     fi
-    ti="`date "+%I:%M %p"`"
-    vol="`amixer -D pulse get Master | grep Left: | cut -d '[' -f2 | cut -d ']' -f1`"
-    mute="`amixer -D pulse get Master | grep Left: | cut -d '[' -f3 | cut -d ']' -f1`"
-    bat="`upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | cut -d':' -f2 | sed 's/ //g'`"
+    ti=$(date "+%I:%M %p")
+    vol=$(amixer -D pulse get Master | grep Left: | cut -d '[' -f2 | cut -d ']' -f1)
+    mute=$(amixer -D pulse get Master | grep Left: | cut -d '[' -f3 | cut -d ']' -f1)
+    bat=$(upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | cut -d':' -f2 | sed 's/ //g')
 
     # WIFI:
     printf '{"name":"wifi","color":"#FFFFFF","full_text":"'"$essid"' '"$strength"'%%"},'

--- a/i3stsh
+++ b/i3stsh
@@ -37,9 +37,9 @@ do
     # VOLUME:
     if [ "$mute" != "off" ]
     then
-        printf '{"name":"vol","color":"#FFFFFF","full_text":"VOL: '"$vol"'%"},'
+        printf '{"name":"vol","color":"#FFFFFF","full_text":"VOL: '"$vol"'%%"},'
     else
-        printf '{"name":"vol","color":"#FFFF00","full_text":"MUTED ('"$vol"'%)"},'
+        printf '{"name":"vol","color":"#FFFF00","full_text":"MUTED ('"$vol"'%%)"},'
     fi
 
     # DOY:
@@ -52,7 +52,7 @@ do
     printf '{"name":"time","color":"#00AAFF","full_text":"'"$ti"'"},'
 
     # BATTERY
-    printf '{"name":"bat","color":"#FFFFFF","full_text":"'"$bat"'% "}'
+    printf '{"name":"bat","color":"#FFFFFF","full_text":"'"$bat"'%% "}'
     
 
     printf "],\n"

--- a/i3stsh
+++ b/i3stsh
@@ -27,7 +27,7 @@ do
     printf '{"name":"wifi","color":"#FFFFFF","full_text":"%s %s%%"},' "$essid" "$strength"
 
     # VPN:
-    if [ "$vpn_state" == "tun0: connected to tun0" ]
+    if [[ $vpn_state = "tun0: connected to tun0" ]]
     then
         printf '{"name":"vpn","color":"#00FF00","full_text":"VPN: YES"},'
     else
@@ -35,7 +35,7 @@ do
     fi
 
     # VOLUME:
-    if [ "$mute" != "off" ]
+    if [[ $mute != "off" ]]
     then
         printf '{"name":"vol","color":"#FFFFFF","full_text":"VOL: %s%"},' "$vol"
     else

--- a/i3stsh
+++ b/i3stsh
@@ -5,7 +5,7 @@
 echo '{"version":1}'
 echo '['
 counter=0
-while [ 0 == 0 ]
+while true
 do
     printf '['
 


### PR DESCRIPTION
Most of these commits have fairly straightforward commit messages, so I won't go into too much detail here. It's a nice little script, and it totally worked fine without my changes (except for 54225bc, which properly shows percentages in your printfs), but I thought you might be interested in some of the newer, tidier, more reliable, shinier features of bash to do the same jobs. Also when I say "newer," most of these have been around since at least Bash 3, which is 13 years old!

I gave this a quick test and it all seemed to work fine, except many of the commands you called didn't run because I didn't have them installed on my Mac. I did get the same output displayed both before and after my edits though (with the exception of the fixed percent symbols), so it should be fine.

Nice job!